### PR TITLE
docs: add organization content section and update citation format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Digital Life Project 2 (DLP3D) is an open-source real-time framework that brings
     </a>
 </div>
 
+## Content
+
+This organization contains the following key repositories:
+
+- **[dlp3d.ai](https://github.com/dlp3d-ai/dlp3d.ai): the main entry point, start here!**
+- [orchestrator](https://github.com/dlp3d-ai/orchestrator): coordinates and synchronizes all components.
+- [web_backend](https://github.com/dlp3d-ai/web_backend): manages the backend web services.
+- [speech2motion](https://github.com/dlp3d-ai/speech2motion): converts speech into body animation.
+- [audio2face](https://github.com/dlp3d-ai/audio2face): generates facial animation from audio.
+- [MotionDataViewer](https://github.com/dlp3d-ai/MotionDataViewer): visualizes and inspects motion data.
 
 ## Get Started
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -34,6 +34,16 @@
     </a>
 </div>
 
+## 内容
+
+本组织包含以下关键仓库：
+
+- **[dlp3d.ai](https://github.com/dlp3d-ai/dlp3d.ai)：主要入口，从这里开始！**
+- [orchestrator](https://github.com/dlp3d-ai/orchestrator)：协调并同步所有组件。
+- [web_backend](https://github.com/dlp3d-ai/web_backend)：管理后端 Web 服务。
+- [speech2motion](https://github.com/dlp3d-ai/speech2motion)：根据语音生成肢体动画。
+- [audio2face](https://github.com/dlp3d-ai/audio2face)：根据语音生成面部动画。
+- [MotionDataViewer](https://github.com/dlp3d-ai/MotionDataViewer)：可视化检查动画数据。
 
 ## 快速开始
 


### PR DESCRIPTION
## Summary

This PR updates both README.md and docs/README_CN.md to add a new Content section listing key repositories in the organization, and updates the citation format from \`@misc\` to \`@inproceedings\` with complete academic publication details.

## Changes

- Added new \"Content\" / \"内容\" section in both README files listing key repositories (dlp3d.ai, orchestrator, web_backend, speech2motion, audio2face, MotionDataViewer)
- Updated citation format from \`@misc\` to \`@inproceedings\` for proper academic reference
- Added complete publication metadata including pages, ISBN, publisher, address, URL, DOI, abstract, article number, number of pages, location, and series
- Fixed author order (adjusted Lin, Zhengyu and Jang, Huimuk positions)
- Removed duplicate \`year\` field in citation
